### PR TITLE
Pin min nova version that supports null currency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "beberlei/assert": "^3.3",
         "cakephp/chronos": "^1.2.3|^2.0",
         "illuminate/contracts": "^8.0",
-        "laravel/nova": "^3.0",
+        "laravel/nova": "^3.20",
         "marc-mabe/php-enum": "^4.4",
         "spatie/laravel-package-tools": "^1.1"
     },


### PR DESCRIPTION
Fixes possible test matrix failures executed against --prefer-lowest install.