### PR TITLE
Replace framework dependency w/explicit packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,9 @@
         "php": "^7.4|^8.0",
         "beberlei/assert": "^3.3",
         "cakephp/chronos": "^1.2.3|^2.0",
+        "illuminate/collections": "^8.0",
         "illuminate/contracts": "^8.0",
-        "laravel/framework": "^8.2",
+        "illuminate/database": "^8.14",
         "laravel/nova": "^3.20",
         "marc-mabe/php-enum": "^4.4",
         "spatie/laravel-package-tools": "^1.1"

--- a/src/Enums/AppliesTo.php
+++ b/src/Enums/AppliesTo.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Support\Enums;
+
+use MabeEnum\Enum;
+
+/**
+ * @method static AppliesTo ORDER()
+ * @method static AppliesTo PARTICIPANT()
+ * @method static AppliesTo SINGLE_PARTICIPANT()
+ * @method static AppliesTo BOOKING()
+ * @method static AppliesTo PRODUCT()
+ * @method static AppliesTo BOOKING_AND_PRODUCT()
+
+ * @psalm-immutable
+ */
+class AppliesTo extends Enum
+{
+    const ORDER = 'order';
+    const PARTICIPANT = 'participant';
+    const SINGLE_PARTICIPANT = 'single_participant';
+    const BOOKING = 'booking';
+    const PRODUCT = 'product';
+    const BOOKING_AND_PRODUCT = 'each';
+}


### PR DESCRIPTION
8.14 ensures `foreignIdFor` blueprint method exists.  Also ensures latest `HasFactory` trait which was cause of 8.2 pin. 

Promotes AppliesTo enum to support - its values are common across multiple packages.