### PR TITLE
Models in Tipoff Packages #21

### DIFF
--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -8,9 +8,9 @@ return [
 
         'booking' => \App\Models\Booking::class,
 
-        'cart' => \App\Models\Cart::class,
+        'cart' => \Tipoff\Checkout\Models\Cart::class,
 
-        'cart_item' => \App\Models\CartItem::class,
+        'cart_item' => \Tipoff\Checkout\Models\CartItem::class,
 
         'competitor' => \Tipoff\Reviews\Models\Competitor::class,
 
@@ -44,7 +44,9 @@ return [
 
         'note' => \App\Models\Note::class,
 
-        'order' => \App\Models\Order::class,
+        'order' => \Tipoff\Checkout\Models\Order::class,
+
+        'order_item' => \Tipoff\Checkout\Models\OrderItem::class,
 
         'page' => \DrewRoberts\Blog\Models\Page::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -24,7 +24,7 @@ return [
 
         'feedback' => \App\Models\Feedback::class,
 
-        'flex_day' => \App\Models\FlexDay::class,
+        'flex_day' => \Tipoff\FlexScheduling\Models\FlexDay::class,
 
         'game' => \Tipoff\Scheduling\Models\Game::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -18,7 +18,7 @@ return [
 
         'customer' => \Tipoff\Addresses\Models\Customer::class, // Will be renamed later to address when new features added
 
-        'discount' => \App\Models\Discount::class,
+        'discount' => \Tipoff\Discounts\Models\Discount::class,
 
         'fee' => \Tipoff\Fees\Models\Fee::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -78,7 +78,7 @@ return [
 
         'snapshot' => \Tipoff\Reviews\Models\Snapshot::class,
 
-        'status' => \App\Models\Status::class,
+        'status' => \Tipoff\Statuses\Models\Status::class,
 
         'supervision' => \Tipoff\EscapeRoom\Models\Supervision::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -42,7 +42,7 @@ return [
 
         'market' => \Tipoff\Locations\Models\Market::class,
 
-        'note' => \App\Models\Note::class,
+        'note' => \Tipoff\Notes\Models\Note::class,
 
         'order' => \Tipoff\Checkout\Models\Order::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -16,7 +16,7 @@ return [
 
         'contact' => \App\Models\Contact::class,
 
-        'customer' => \App\Models\Customer::class,
+        'customer' => \Tipoff\Addresses\Models\Customer::class, // Will be renamed later to address when new features added
 
         'discount' => \App\Models\Discount::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -4,7 +4,7 @@ return [
 
     'model_class' => [
 
-        'block' => \App\Models\Block::class,
+        'block' => \Tipoff\Scheduling\Models\Block::class,
 
         'booking' => \App\Models\Booking::class,
 
@@ -26,9 +26,9 @@ return [
 
         'flex_day' => \App\Models\FlexDay::class,
 
-        'game' => \App\Models\Game::class,
+        'game' => \Tipoff\Scheduling\Models\Game::class,
 
-        'hold' => \App\Models\Hold::class,
+        'hold' => \Tipoff\Scheduling\Models\Hold::class,
 
         'image' => \DrewRoberts\Media\Models\Image::class,
 
@@ -56,7 +56,7 @@ return [
 
         'rate' => \Tipoff\EscapeRoom\Models\Rate::class,
 
-        'recurring_schedule' => \App\Models\RecurringSchedule::class,
+        'recurring_schedule' => \Tipoff\Scheduling\Models\RecurringSchedule::class,
 
         'refund' => \App\Models\Refund::class,
 
@@ -66,13 +66,13 @@ return [
 
         'schedule' => \App\Models\Schedule::class,
 
-        'schedule_eraser' => \App\Models\ScheduleEraser::class,
+        'schedule_eraser' => \Tipoff\Scheduling\Models\ScheduleEraser::class,
 
         'series' => \DrewRoberts\Blog\Models\Series::class,
 
         'signature' => \App\Models\Signature::class,
 
-        'slot' => \App\Models\Slot::class,
+        'slot' => \Tipoff\Scheduling\Models\Slot::class,
 
         'snapshot' => \App\Models\Snapshot::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -72,7 +72,7 @@ return [
 
         'series' => \DrewRoberts\Blog\Models\Series::class,
 
-        'signature' => \App\Models\Signature::class,
+        'signature' => \Tipoff\Waivers\Models\Signature::class,
 
         'slot' => \Tipoff\Scheduling\Models\Slot::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -38,9 +38,9 @@ return [
 
         'key' => \App\Models\Key::class,
 
-        'location' => \App\Models\Location::class,
+        'location' => \Tipoff\Locations\Models\Location::class,
 
-        'market' => \App\Models\Market::class,
+        'market' => \Tipoff\Locations\Models\Market::class,
 
         'note' => \App\Models\Note::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -50,7 +50,7 @@ return [
 
         'page' => \DrewRoberts\Blog\Models\Page::class,
 
-        'participant' => \App\Models\Participant::class,
+        'participant' => \Tipoff\EscapeRoom\Participant::class,
 
         'payment' => \Tipoff\Payments\Models\Payment::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -14,7 +14,7 @@ return [
 
         'competitor' => \Tipoff\Reviews\Models\Competitor::class,
 
-        'contact' => \App\Models\Contact::class,
+        'contact' => \Tipoff\Forms\Models\Contact::class,
 
         'customer' => \Tipoff\Addresses\Models\Customer::class, // Will be renamed later to address when new features added
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -54,7 +54,7 @@ return [
 
         'post' => \DrewRoberts\Blog\Models\Post::class,
 
-        'rate' => \App\Models\Rate::class,
+        'rate' => \Tipoff\EscapeRoom\Models\Rate::class,
 
         'recurring_schedule' => \App\Models\RecurringSchedule::class,
 
@@ -62,7 +62,7 @@ return [
 
         'review' => \App\Models\Review::class,
 
-        'room' => \App\Models\Room::class,
+        'room' => \Tipoff\EscapeRoom\Models\Room::class,
 
         'schedule' => \App\Models\Schedule::class,
 
@@ -78,13 +78,13 @@ return [
 
         'status' => \App\Models\Status::class,
 
-        'supervision' => \App\Models\Supervision::class,
+        'supervision' => \Tipoff\EscapeRoom\Models\Supervision::class,
 
         'tag' => \DrewRoberts\Media\Models\Tag::class,
 
         'tax' => \Tipoff\Taxes\Models\Tax::class,
 
-        'theme' => \App\Models\Theme::class,
+        'theme' => \Tipoff\EscapeRoom\Models\Theme::class,
 
         'topic' => \DrewRoberts\Blog\Models\Topic::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -82,7 +82,7 @@ return [
 
         'tag' => \DrewRoberts\Media\Models\Tag::class,
 
-        'tax' => \App\Models\Tax::class,
+        'tax' => \Tipoff\Taxes\Models\Tax::class,
 
         'theme' => \App\Models\Theme::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -66,8 +66,6 @@ return [
 
         'room' => \Tipoff\EscapeRoom\Models\Room::class,
 
-        'schedule' => \App\Models\Schedule::class,
-
         'schedule_eraser' => \Tipoff\Scheduling\Models\ScheduleEraser::class,
 
         'series' => \DrewRoberts\Blog\Models\Series::class,

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -60,7 +60,7 @@ return [
 
         'recurring_schedule' => \Tipoff\Scheduling\Models\RecurringSchedule::class,
 
-        'refund' => \App\Models\Refund::class,
+        'refund' => \Tipoff\Refunds\Models\Refund::class,
 
         'review' => \Tipoff\Reviews\Models\Review::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -22,7 +22,7 @@ return [
 
         'fee' => \Tipoff\Fees\Models\Fee::class,
 
-        'feedback' => \App\Models\Feedback::class,
+        'feedback' => \Tipoff\Feedback\Models\Feedback::class,
 
         'flex_day' => \Tipoff\FlexScheduling\Models\FlexDay::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -34,7 +34,7 @@ return [
 
         'insight' => \Tipoff\Reviews\Models\Insight::class,
 
-        'invoice' => \App\Models\Invoice::class,
+        'invoice' => \Tipoff\Invoices\Models\Invoice::class,
 
         'key' => \Tipoff\Reviews\Models\Key::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -94,9 +94,9 @@ return [
 
         'video' => \DrewRoberts\Media\Models\Video::class,
 
-        'voucher' => \App\Models\Voucher::class,
+        'voucher' => \Tipoff\Vouchers\Models\Voucher::class,
 
-        'voucher_type' => \App\Models\VoucherType::class,
+        'voucher_type' => \Tipoff\Vouchers\Models\VoucherType::class,
 
     ]
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -6,7 +6,7 @@ return [
 
         'block' => \Tipoff\Scheduling\Models\Block::class,
 
-        'booking' => \App\Models\Booking::class,
+        'booking' => \Tipoff\Bookings\Models\Booking::class,
 
         'cart' => \Tipoff\Checkout\Models\Cart::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -52,7 +52,7 @@ return [
 
         'participant' => \App\Models\Participant::class,
 
-        'payment' => \App\Models\Payment::class,
+        'payment' => \Tipoff\Payments\Models\Payment::class,
 
         'post' => \DrewRoberts\Blog\Models\Post::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -20,7 +20,7 @@ return [
 
         'discount' => \App\Models\Discount::class,
 
-        'fee' => \App\Models\Fee::class,
+        'fee' => \Tipoff\Fees\Models\Fee::class,
 
         'feedback' => \App\Models\Feedback::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -12,7 +12,7 @@ return [
 
         'cart_item' => \App\Models\CartItem::class,
 
-        'competitor' => \App\Models\Competitor::class,
+        'competitor' => \Tipoff\Reviews\Models\Competitor::class,
 
         'contact' => \App\Models\Contact::class,
 
@@ -32,11 +32,11 @@ return [
 
         'image' => \DrewRoberts\Media\Models\Image::class,
 
-        'insight' => \App\Models\Insight::class,
+        'insight' => \Tipoff\Reviews\Models\Insight::class,
 
         'invoice' => \App\Models\Invoice::class,
 
-        'key' => \App\Models\Key::class,
+        'key' => \Tipoff\Reviews\Models\Key::class,
 
         'location' => \Tipoff\Locations\Models\Location::class,
 
@@ -60,7 +60,7 @@ return [
 
         'refund' => \App\Models\Refund::class,
 
-        'review' => \App\Models\Review::class,
+        'review' => \Tipoff\Reviews\Models\Review::class,
 
         'room' => \Tipoff\EscapeRoom\Models\Room::class,
 
@@ -74,7 +74,7 @@ return [
 
         'slot' => \Tipoff\Scheduling\Models\Slot::class,
 
-        'snapshot' => \App\Models\Snapshot::class,
+        'snapshot' => \Tipoff\Reviews\Models\Snapshot::class,
 
         'status' => \App\Models\Status::class,
 


### PR DESCRIPTION
I already marked the models that are located in the following 2 packages:

- https://github.com/drewroberts/media
- https://github.com/drewroberts/blog

Those models (with their corresponding migrations, factories, nova resources, policies, etc.) have already been completed moved from the main repository over to those packages. We're in the process of moving everything for the models in these config files completely over to the corresponding packages listed in the commits below: