### PR TITLE
Bump min version of spatie/laravel-package-tools to 1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "illuminate/database": "^8.14",
         "laravel/nova": "^3.20",
         "marc-mabe/php-enum": "^4.4",
-        "spatie/laravel-package-tools": "^1.1"
+        "spatie/laravel-package-tools": "^1.3"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0",


### PR DESCRIPTION
I have an issue when with the `migrationFileExists` method running the test for the Escape Room package. Try to bump the min version to 1.3 to fix that https://github.com/spatie/laravel-package-tools/pull/7