### PR TITLE
Model aliases

### DIFF
--- a/src/Support.php
+++ b/src/Support.php
@@ -10,7 +10,8 @@ class Support
      * @param  string  $name
      * @return mixed
      */
-    public static function resolve($name) {
+    public static function resolve($name)
+    {
         return app($name);
     }
 }

--- a/src/Support.php
+++ b/src/Support.php
@@ -4,4 +4,13 @@ namespace Tipoff\Support;
 
 class Support
 {
+    /**
+     * Resolve a service from the container.
+     *
+     * @param  string  $name
+     * @return mixed
+     */
+    public static function resolve($name) {
+        return app($name);
+    }
 }

--- a/src/SupportServiceProvider.php
+++ b/src/SupportServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Tipoff\Support;
 
+use Illuminate\Foundation\AliasLoader;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Tipoff\Support\Commands\SupportCommand;
@@ -19,5 +20,22 @@ class SupportServiceProvider extends PackageServiceProvider
             ->name('support')
             ->hasConfigFile('tipoff')
             ->hasCommand(SupportCommand::class);
+    }
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $loader = AliasLoader::getInstance();
+        $aliases = $loader->getAliases();
+
+        foreach (config('tipoff.model_class') as $alias => $class) {
+            if (empty($aliases[$alias])) {
+                $loader->alias($alias, $class);
+            }
+        }
     }
 }

--- a/tests/Unit/Resolver/ModelResolvingTest.php
+++ b/tests/Unit/Resolver/ModelResolvingTest.php
@@ -19,5 +19,13 @@ class ModelResolvingTest extends TestCase
             array_intersect($loader->getAliases(), config('tipoff.model_class'))
         );
     }
+
+    /** @test */
+    public function test_if_class_can_be_overwrited()
+    {
+        $loader = AliasLoader::getInstance();
+        $loader->alias('user', \Tipoff\Support\Models\BaseModel::class);
+        $this->assertEquals(get_class(resolve('user')), \Tipoff\Support\Models\BaseModel::class);
+    }
 }
 

--- a/tests/Unit/Resolver/ModelResolvingTest.php
+++ b/tests/Unit/Resolver/ModelResolvingTest.php
@@ -20,4 +20,3 @@ class ModelResolvingTest extends TestCase
         );
     }
 }
-

--- a/tests/Unit/Resolver/ModelResolvingTest.php
+++ b/tests/Unit/Resolver/ModelResolvingTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Support\Tests\Unit\Resolver;
+
+use Illuminate\Foundation\AliasLoader;
+use Tipoff\Support\Tests\TestCase;
+
+class ModelResolvingTest extends TestCase
+{
+    /** @test */
+    public function test_if_model_aliases_are_loaded()
+    {
+        $loader = AliasLoader::getInstance();
+
+        $this->assertEquals(
+            config('tipoff.model_class'),
+            array_intersect($loader->getAliases(), config('tipoff.model_class'))
+        );
+    }
+}
+


### PR DESCRIPTION
Model classes registered as an alias by default so models can be resolved by name directly from the container.