### PR TITLE
Allow Model as parameter of randomOrCreate

### DIFF
--- a/src/Helpers/Test.php
+++ b/src/Helpers/Test.php
@@ -5,21 +5,21 @@ declare(strict_types=1);
 use Illuminate\Database\Eloquent\Model;
 
 if (! function_exists('randomOrCreate')) {
-	/**
-	 * Ger random model or create it using factory.
-	 *
-	 * @param  string|Model $classNameOrModel
-	 * @return Model
-	 */
+    /**
+     * Ger random model or create it using factory.
+     *
+     * @param  string|Model $classNameOrModel
+     * @return Model
+     */
     function randomOrCreate($classNameOrModel): Model
     {
-    	if (is_string($classNameOrModel)) {
-    		$className = $classNameOrModel;
-    	}
+        if (is_string($classNameOrModel)) {
+            $className = $classNameOrModel;
+        }
 
-    	if ($classNameOrModel instanceof Model) {
-    		$className = $classNameOrModel;
-    	}
+        if ($classNameOrModel instanceof Model) {
+            $className = $classNameOrModel;
+        }
 
         if ($className::count() > 0) {
             return $className::all()->random();

--- a/src/Helpers/Test.php
+++ b/src/Helpers/Test.php
@@ -5,8 +5,22 @@ declare(strict_types=1);
 use Illuminate\Database\Eloquent\Model;
 
 if (! function_exists('randomOrCreate')) {
-    function randomOrCreate(string $className): Model
+	/**
+	 * Ger random model or create it using factory.
+	 *
+	 * @param  string|Model $classNameOrModel
+	 * @return Model
+	 */
+    function randomOrCreate($classNameOrModel): Model
     {
+    	if (is_string($classNameOrModel)) {
+    		$className = $classNameOrModel;
+    	}
+
+    	if ($classNameOrModel instanceof Model) {
+    		$className = $classNameOrModel;
+    	}
+
         if ($className::count() > 0) {
             return $className::all()->random();
         }

--- a/src/Helpers/Test.php
+++ b/src/Helpers/Test.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 if (! function_exists('randomOrCreate')) {
 	/**
-	 * Ger random model or create it using factory.
+	 * Ger random model or create model using factory.
 	 *
 	 * @param  string|Model $classNameOrModel
 	 * @return Model
@@ -18,7 +18,7 @@ if (! function_exists('randomOrCreate')) {
     	}
 
     	if ($classNameOrModel instanceof Model) {
-    		$className = $classNameOrModel;
+    		$className = class_basename($classNameOrModel);
     	}
 
         if ($className::count() > 0) {

--- a/src/Helpers/Test.php
+++ b/src/Helpers/Test.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 if (! function_exists('randomOrCreate')) {
     /**
-     * Ger random model or create model using factory.
+     * Get random model or create model using factory.
      *
      * @param  string|Model $classNameOrModel
      * @return Model

--- a/src/Helpers/Test.php
+++ b/src/Helpers/Test.php
@@ -5,21 +5,21 @@ declare(strict_types=1);
 use Illuminate\Database\Eloquent\Model;
 
 if (! function_exists('randomOrCreate')) {
-	/**
-	 * Ger random model or create model using factory.
-	 *
-	 * @param  string|Model $classNameOrModel
-	 * @return Model
-	 */
+    /**
+     * Ger random model or create model using factory.
+     *
+     * @param  string|Model $classNameOrModel
+     * @return Model
+     */
     function randomOrCreate($classNameOrModel): Model
     {
         if (is_string($classNameOrModel)) {
             $className = $classNameOrModel;
         }
 
-    	if ($classNameOrModel instanceof Model) {
-    		$className = class_basename($classNameOrModel);
-    	}
+        if ($classNameOrModel instanceof Model) {
+            $className = class_basename($classNameOrModel);
+        }
 
         if ($className::count() > 0) {
             return $className::all()->random();


### PR DESCRIPTION
To avoid get_class everywhere, `randomOrCreate` helper now can accept Model as parameter.