### PR TITLE
Allow use of model instance in belongsTo/hasMany

### DIFF
--- a/src/Helpers/Test.php
+++ b/src/Helpers/Test.php
@@ -14,3 +14,38 @@ if (! function_exists('randomOrCreate')) {
         return $className::factory()->create();
     }
 }
+
+if (! function_exists('createModelStub')) {
+    /**
+     * Dynamically defines a model class on the fly if not already defined.  Useful
+     * for creating stub models and there tables to satisfy possible FK dependencies.
+     *
+     * @param string $class
+     */
+    function createModelStub(string $class): void
+    {
+        if (class_exists($class)) {
+            return;
+        }
+
+        $classBasename = class_basename($class);
+        $classNamespace = substr($class, 0, strrpos($class, '\\'));
+
+        $classDef = <<<EOT
+namespace {$classNamespace};
+
+use Illuminate\Database\Eloquent\Model;
+use Tipoff\Support\Models\TestModelStub;
+
+class {$classBasename} extends Model {
+    use TestModelStub;
+
+    protected \$guarded = [
+        'id',
+    ];
+};
+EOT;
+        // alias the anonymous class with your class name
+        eval($classDef);
+    }
+}

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -14,7 +14,9 @@ class BaseModel extends Model
      */
     public function belongsTo($related, $foreignKey = null, $ownerKey = null, $relation = null)
     {
-        Assert::that($related)->classExists();
+        if (is_string($related)) {
+            Assert::that($related)->classExists();
+        }
 
         return parent::belongsTo($related, $foreignKey, $ownerKey, $relation);
     }
@@ -36,7 +38,9 @@ class BaseModel extends Model
      */
     public function hasMany($related, $foreignKey = null, $localKey = null)
     {
-        Assert::that($related)->classExists();
+        if (is_string($related)) {
+            Assert::that($related)->classExists();
+        }
 
         return parent::hasMany($related, $foreignKey, $localKey);
     }

--- a/src/Models/TestModelStub.php
+++ b/src/Models/TestModelStub.php
@@ -21,10 +21,12 @@ trait TestModelStub
     public static function createTable(): void
     {
         $table = (new static)->getTable();
-        Schema::create($table, function (Blueprint $table) {
-            $table->id();
-            $table->timestamps();
-        });
+        if (!Schema::hasTable($table)) {
+            Schema::create($table, function (Blueprint $table) {
+                $table->id();
+                $table->timestamps();
+            });
+        }
     }
 
     /**

--- a/src/Models/TestModelStub.php
+++ b/src/Models/TestModelStub.php
@@ -21,7 +21,7 @@ trait TestModelStub
     public static function createTable(): void
     {
         $table = (new static)->getTable();
-        if (!Schema::hasTable($table)) {
+        if (! Schema::hasTable($table)) {
             Schema::create($table, function (Blueprint $table) {
                 $table->id();
                 $table->timestamps();


### PR DESCRIPTION
* Eliminates need for class_basename in  relations using container `return $this->belongsTo(app('user'), 'creator_id');` 
* TestModelStub checks for table existence before creation
* Refactored `createModelStub` to helpers for use in tests by multiple packages.
