### PR TITLE
Add createNovaResourceStub test helper

### DIFF
--- a/src/Helpers/Test.php
+++ b/src/Helpers/Test.php
@@ -77,7 +77,7 @@ if (! function_exists('createNovaResourceStub')) {
             return;
         }
 
-        $classBasename  = class_basename($novaClass);
+        $classBasename = class_basename($novaClass);
         $classNamespace = substr($novaClass, 0, strrpos($novaClass, '\\'));
 
         $classDef = <<<EOT

--- a/src/Helpers/Test.php
+++ b/src/Helpers/Test.php
@@ -63,3 +63,39 @@ EOT;
         eval($classDef);
     }
 }
+
+if (! function_exists('createNovaResourceStub')) {
+    /**
+     * Dynamically defines a Nova resource class on the fly if not already defined.  Useful
+     * for creating stub resources to allow isolated testing of Nova resources in a package.
+     *
+     * @param string $novaClassName
+     */
+    function createNovaResourceStub(string $novaClass, string $modelClass): void
+    {
+        if (class_exists($novaClass)) {
+            return;
+        }
+
+        $classBasename  = class_basename($novaClass);
+        $classNamespace = substr($novaClass, 0, strrpos($novaClass, '\\'));
+
+        $classDef = <<<EOT
+namespace {$classNamespace};
+
+use Illuminate\Http\Request;
+use Laravel\Nova\Resource;
+
+class {$classBasename} extends Resource
+{
+    public static \$model = \\{$modelClass}::class;
+
+    public function fields(Request \$request)
+    {
+    }
+}
+EOT;
+        // alias the anonymous class with your class name
+        eval($classDef);
+    }
+}


### PR DESCRIPTION
Dynamically defines a Nova resource class on the fly if not already defined.  Useful for creating stub resources to allow isolated testing of Nova resources in a package.