### PR TITLE
Fix for full class name in randomOrCreate

### DIFF
--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -50,7 +50,7 @@ return [
 
         'page' => \DrewRoberts\Blog\Models\Page::class,
 
-        'participant' => \Tipoff\EscapeRoom\Participant::class,
+        'participant' => \Tipoff\EscapeRoom\Models\Participant::class,
 
         'payment' => \Tipoff\Payments\Models\Payment::class,
 
@@ -146,7 +146,7 @@ return [
 
         'page' => \DrewRoberts\Blog\Nova\Page::class,
 
-        'participant' => \Tipoff\EscapeRoom\Participant::class,
+        'participant' => \Tipoff\EscapeRoom\Nova\Participant::class,
 
         'payment' => \Tipoff\Payments\Nova\Payment::class,
 

--- a/src/Helpers/Test.php
+++ b/src/Helpers/Test.php
@@ -18,7 +18,7 @@ if (! function_exists('randomOrCreate')) {
         }
 
         if ($classNameOrModel instanceof Model) {
-            $className = class_basename($classNameOrModel);
+            $className = get_class($classNameOrModel);
         }
 
         if ($className::count() > 0) {

--- a/src/SupportServiceProvider.php
+++ b/src/SupportServiceProvider.php
@@ -40,9 +40,7 @@ class SupportServiceProvider extends PackageServiceProvider
     public function registerModelsAliases(): void
     {
         foreach (config('tipoff.model_class') as $alias => $class) {
-            if (empty($aliases[$alias])) {
-                $this->app->alias($class, $alias);
-            }
+            $this->app->alias($class, $alias);
         }
     }
 
@@ -54,9 +52,7 @@ class SupportServiceProvider extends PackageServiceProvider
     public function registerNovaModelsAliases(): void
     {
         foreach (config('tipoff.nova_class') as $alias => $class) {
-            if (empty($aliases[$alias])) {
-                $this->app->alias($class, 'nova.' . $alias);
-            }
+            $this->app->alias($class, 'nova.' . $alias);
         }
     }
 }

--- a/tests/Unit/Helpers/TestTest.php
+++ b/tests/Unit/Helpers/TestTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Support\Tests\Unit\Helpers;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tipoff\Support\Tests\TestCase;
+
+class TestTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function test_random_or_create()
+    {
+        createModelStub(config('tipoff.model_class.user'));
+        config('tipoff.model_class.user')::createTable();
+
+        // Create by class name
+        $className = config('tipoff.model_class.user');
+        $this->assertIsString($className);
+        $user = randomOrCreate($className);
+        $this->assertNotNull($user);
+
+        // Create with model instance
+        $classInstance = app('user');
+        $this->assertInstanceOf(Model::class, $classInstance);
+        $user = randomOrCreate($classInstance);
+        $this->assertNotNull($user);
+    }
+}


### PR DESCRIPTION
Replaces `class_basename` with `get_class` to fix class not defined errors on usage.