### PR TITLE
Relax id requirements to allow other data types

### DIFF
--- a/src/Contracts/Models/BaseModelInterface.php
+++ b/src/Contracts/Models/BaseModelInterface.php
@@ -10,14 +10,19 @@ interface BaseModelInterface
      * Using docblock typehints to allow implementing classes freedom
      * to include docblock with class specific type
      *
+     * @param mixed $id
      * @return self
      */
-    public static function find(int $id);
+    public static function find($id);
 
     /**
+     * @param mixed $id
      * @return self
      */
-    public static function findOrFail(int $id);
+    public static function findOrFail($id);
 
-    public function getId(): ?int;
+    /**
+     * @return mixed|null
+     */
+    public function getId();
 }

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -46,18 +46,18 @@ class BaseModel extends Model implements BaseModelInterface
         return parent::hasMany($related, $foreignKey, $localKey);
     }
 
-    public static function find(int $id)
+    public static function find($id)
     {
         return static::find($id);
     }
 
-    public static function findOrFail(int $id)
+    public static function findOrFail($id)
     {
         return static::findOrFail($id);
     }
 
-    public function getId(): ?int
+    public function getId()
     {
-        return (int) $this->id;
+        return $this->id;
     }
 }


### PR DESCRIPTION
The int requirement for ids would probably always work for DB backed tipoff models, but is too restrictive for implementations that could be backed by external APIs that use GUIDs or strings as their ids.  