### PR TITLE
Add TipoffServiceProvider/TipoffPackage

### DIFF
--- a/src/SupportServiceProvider.php
+++ b/src/SupportServiceProvider.php
@@ -2,19 +2,12 @@
 
 namespace Tipoff\Support;
 
-use Spatie\LaravelPackageTools\Package;
-use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Tipoff\Support\Commands\SupportCommand;
 
-class SupportServiceProvider extends PackageServiceProvider
+class SupportServiceProvider extends TipoffServiceProvider
 {
-    public function configurePackage(Package $package): void
+    public function configureTipoffPackage(TipoffPackage $package): void
     {
-        /*
-         * This class is a Package Service Provider
-         *
-         * More info: https://github.com/spatie/laravel-package-tools
-         */
         $package
             ->name('support')
             ->hasConfigFile('tipoff')

--- a/src/TipoffPackage.php
+++ b/src/TipoffPackage.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Support;
+
+use Spatie\LaravelPackageTools\Package;
+
+class TipoffPackage extends Package
+{
+    /**
+     * [
+     *   EventClass => [
+     *      HandlerClass,
+     *      // ...
+     *      ],
+     *   // ...
+     * ]
+     */
+    public array $events = [];
+
+    /**
+     * [
+     *   ModelClass => PolicyClass,
+     *   // ...
+     * ]
+     */
+    public array $policies = [];
+
+    /**
+     * [
+     *   ModelInterface => ModelClass,
+     *   // ...
+     * ]
+     */
+    public array $modelInterfaces = [];
+
+    /**
+     * [
+     *   ServiceInterface => ServiceImplementation,
+     *   // ...
+     * ]
+     */
+    public array $services = [];
+
+    public function __construct(Package $package)
+    {
+        $this->setBasePath($package->basePath);
+    }
+
+    public function hasPolicies(array $policies): self
+    {
+        $this->policies = array_merge($this->policies, $policies);
+
+        return $this;
+    }
+
+    public function hasEvents(array $events): self
+    {
+        foreach ($events as $event => $listeners) {
+            $this->events[$event] = array_values(
+                array_unique(
+                    array_merge($this->events[$event] ?? [], $listeners)
+                )
+            );
+        }
+
+        return $this;
+    }
+
+    public function hasModelInterfaces(array $modelInterfaces): self
+    {
+        $this->modelInterfaces = array_merge($this->modelInterfaces, $modelInterfaces);
+
+        return $this;
+    }
+
+    public function hasServices(array $services): self
+    {
+        $this->services = array_merge($this->services, $services);
+
+        return $this;
+    }
+}

--- a/src/TipoffServiceProvider.php
+++ b/src/TipoffServiceProvider.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Support;
+
+use Assert\Assert;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Gate;
+use ReflectionClass;
+use Spatie\LaravelPackageTools\Exceptions\InvalidPackage;
+use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\PackageServiceProvider;
+
+abstract class TipoffServiceProvider extends PackageServiceProvider
+{
+    abstract public function configureTipoffPackage(TipoffPackage $tipoffPackage): void;
+
+    /**
+     * Override required to inject TipoffPackage class as replacement
+     * and then invoke new abstract for tipoff package configuration
+     */
+    public function configurePackage(Package $package): void
+    {
+        $this->package = new TipoffPackage($package);
+
+        $this->configureTipoffPackage($this->package);
+    }
+
+    public function bootingPackage()
+    {
+        $this->loadMigrationsFrom($this->package->basePath.'/../database/migrations');
+    }
+
+    public function packageRegistered()
+    {
+        /** @var TipoffPackage $package */
+        $package = $this->package;
+
+        // Model interfaces
+        foreach ($package->modelInterfaces as $interface => $implementation) {
+            if (!(new ReflectionClass($implementation))->implementsInterface($interface)) {
+                throw new \InvalidArgumentException("{$implementation} does not implement {$interface}");
+            }
+            $this->app->bind($interface, $implementation);
+        }
+
+        // Service interfaces
+        foreach ($package->services as $interface => $implementation) {
+            if (!(new ReflectionClass($implementation))->implementsInterface($interface)) {
+                throw new \InvalidArgumentException("{$implementation} does not implement {$interface}");
+            }
+            $this->app->singleton($interface, $implementation);
+        }
+
+        // Policies
+        foreach ($package->policies as $model => $policy) {
+            if (!is_a($model, Model::class, true)) {
+                throw new \InvalidArgumentException("{$model} is not a Model instance");
+            }
+            Gate::policy($model, $policy);
+        }
+
+        // Events
+        foreach ($package->events as $event => $listeners) {
+            foreach (array_unique($listeners) as $listener) {
+                Event::listen($event, $listener);
+            }
+        }
+    }
+}

--- a/src/TipoffServiceProvider.php
+++ b/src/TipoffServiceProvider.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Tipoff\Support;
 
-use Assert\Assert;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use ReflectionClass;
-use Spatie\LaravelPackageTools\Exceptions\InvalidPackage;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -40,7 +38,7 @@ abstract class TipoffServiceProvider extends PackageServiceProvider
 
         // Model interfaces
         foreach ($package->modelInterfaces as $interface => $implementation) {
-            if (!(new ReflectionClass($implementation))->implementsInterface($interface)) {
+            if (! (new ReflectionClass($implementation))->implementsInterface($interface)) {
                 throw new \InvalidArgumentException("{$implementation} does not implement {$interface}");
             }
             $this->app->bind($interface, $implementation);
@@ -48,7 +46,7 @@ abstract class TipoffServiceProvider extends PackageServiceProvider
 
         // Service interfaces
         foreach ($package->services as $interface => $implementation) {
-            if (!(new ReflectionClass($implementation))->implementsInterface($interface)) {
+            if (! (new ReflectionClass($implementation))->implementsInterface($interface)) {
                 throw new \InvalidArgumentException("{$implementation} does not implement {$interface}");
             }
             $this->app->singleton($interface, $implementation);
@@ -56,7 +54,7 @@ abstract class TipoffServiceProvider extends PackageServiceProvider
 
         // Policies
         foreach ($package->policies as $model => $policy) {
-            if (!is_a($model, Model::class, true)) {
+            if (! is_a($model, Model::class, true)) {
                 throw new \InvalidArgumentException("{$model} is not a Model instance");
             }
             Gate::policy($model, $policy);

--- a/tests/Unit/TipoffPackageTest.php
+++ b/tests/Unit/TipoffPackageTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Support\Tests\Unit;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\LaravelPackageTools\Package;
+use Tipoff\Support\Contracts\Models\BaseModelInterface;
+use Tipoff\Support\Contracts\Services\BaseService;
+use Tipoff\Support\Models\BaseModel;
+use Tipoff\Support\TipoffPackage;
+use Tipoff\Support\TipoffServiceProvider;
+use Tipoff\Support\Tests\TestCase;
+
+class TipoffPackageTest extends TestCase
+{
+    /** @test */
+    public function policies_are_merged()
+    {
+        $provider = new TestServiceProvider($this->app, function (TipoffPackage $package) {
+            $package
+                ->hasPolicies([Model::class => 'b'])
+                ->hasPolicies([BaseModel::class => 'c'])
+                ->hasPolicies([Model::class => 'c']);
+        });
+
+        $package = $provider->register()->getPackage();
+        $this->assertCount(2, $package->policies);
+        $this->assertEquals([
+            BaseModel::class => 'c',
+            Model::class => 'c',
+        ], $package->policies);
+    }
+
+    /** @test */
+    public function policies_require_models()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('notamodel is not a Model instance');
+
+        $provider = new TestServiceProvider($this->app, function (TipoffPackage $package) {
+            $package
+                ->hasPolicies(['notamodel' => 'b']);
+        });
+
+        $provider->register()->getPackage();
+    }
+
+    /** @test */
+    public function model_interfaces_are_merged()
+    {
+        $provider = new TestServiceProvider($this->app, function (TipoffPackage $package) {
+            $package
+                ->hasModelInterfaces([BaseModelInterface::class => BaseModel::class])
+                ->hasModelInterfaces([TestModelInterface::class => TestModel::class])
+                ->hasModelInterfaces([BaseModelInterface::class => BaseModel::class]);
+        });
+
+        $package = $provider->register()->getPackage();
+        $this->assertCount(2, $package->modelInterfaces);
+        $this->assertEquals([
+            BaseModelInterface::class => BaseModel::class,
+            TestModelInterface::class => TestModel::class,
+        ], $package->modelInterfaces);
+    }
+
+    /** @test */
+    public function model_interfaces_require_valid_implementation()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Tipoff\Support\Models\BaseModel does not implement Tipoff\Support\Tests\Unit\TestModelInterface');
+
+        $provider = new TestServiceProvider($this->app, function (TipoffPackage $package) {
+            $package
+                ->hasModelInterfaces([TestModelInterface::class => BaseModel::class]);
+        });
+
+        $provider->register()->getPackage();
+    }
+
+    /** @test */
+    public function services_are_merged()
+    {
+        $provider = new TestServiceProvider($this->app, function (TipoffPackage $package) {
+            $package
+                ->hasServices([BaseService::class => BaseServiceImplementation::class])
+                ->hasServices([TestService::class => TestServiceImplementation::class])
+                ->hasServices([BaseService::class => BaseServiceImplementation::class]);
+        });
+
+        $package = $provider->register()->getPackage();
+        $this->assertCount(2, $package->services);
+        $this->assertEquals([
+            BaseService::class => BaseServiceImplementation::class,
+            TestService::class => TestServiceImplementation::class,
+        ], $package->services);
+    }
+
+    /** @test */
+    public function services_require_valid_implementation()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Tipoff\Support\Tests\Unit\BaseServiceImplementation does not implement Tipoff\Support\Tests\Unit\TestService');
+
+        $provider = new TestServiceProvider($this->app, function (TipoffPackage $package) {
+            $package
+                ->hasServices([TestService::class => BaseServiceImplementation::class]);
+        });
+
+        $provider->register()->getPackage();
+    }
+
+    /** @test */
+    public function events_are_merged_properly()
+    {
+        $provider = new TestServiceProvider($this->app, function (TipoffPackage $package) {
+            $package
+                ->hasEvents([
+                    'a' => [
+                        '1',
+                        '2',
+                        '3',
+                    ],
+                    'b' => [
+                        '4',
+                        '5',
+                        '6',
+                    ],
+                ])
+                ->hasEvents([
+                    'a' => [
+                        '3',
+                        '4',
+                    ],
+                    'b' => [
+                        '4',
+                        '5',
+                        '6',
+                    ],
+                    'c' => [
+                        '4',
+                        '5',
+                        '6',
+                    ],
+                ]);
+        });
+
+        $package = $provider->register()->getPackage();
+        $this->assertCount(3, $package->events);
+        $this->assertEquals([
+            'a' => [
+                '1',
+                '2',
+                '3',
+                '4',
+            ],
+            'b' => [
+                '4',
+                '5',
+                '6',
+            ],
+            'c' => [
+                '4',
+                '5',
+                '6',
+            ],
+        ], $package->events);
+    }
+}
+
+class TestServiceProvider extends TipoffServiceProvider
+{
+    private \Closure $testSetup;
+
+    public function __construct($app, \Closure $testSetup)
+    {
+        parent::__construct($app);
+
+        $this->testSetup = $testSetup;
+    }
+
+    public function configureTipoffPackage(TipoffPackage $package): void
+    {
+        ($this->testSetup)($package->name('test'));
+    }
+
+    public function getPackage(): TipoffPackage
+    {
+        return $this->package;
+    }
+}
+
+interface TestService extends BaseService
+{
+
+}
+
+class BaseServiceImplementation implements BaseService
+{
+
+}
+
+class TestServiceImplementation implements TestService
+{
+
+}
+
+interface TestModelInterface extends BaseModelInterface
+{
+
+}
+
+class TestModel extends BaseModel implements TestModelInterface
+{
+
+}

--- a/tests/Unit/TipoffPackageTest.php
+++ b/tests/Unit/TipoffPackageTest.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Tipoff\Support\Tests\Unit;
 
 use Illuminate\Database\Eloquent\Model;
-use Spatie\LaravelPackageTools\Package;
 use Tipoff\Support\Contracts\Models\BaseModelInterface;
 use Tipoff\Support\Contracts\Services\BaseService;
 use Tipoff\Support\Models\BaseModel;
+use Tipoff\Support\Tests\TestCase;
 use Tipoff\Support\TipoffPackage;
 use Tipoff\Support\TipoffServiceProvider;
-use Tipoff\Support\Tests\TestCase;
 
 class TipoffPackageTest extends TestCase
 {
@@ -193,25 +192,20 @@ class TestServiceProvider extends TipoffServiceProvider
 
 interface TestService extends BaseService
 {
-
 }
 
 class BaseServiceImplementation implements BaseService
 {
-
 }
 
 class TestServiceImplementation implements TestService
 {
-
 }
 
 interface TestModelInterface extends BaseModelInterface
 {
-
 }
 
 class TestModel extends BaseModel implements TestModelInterface
 {
-
 }


### PR DESCRIPTION
Extends Spatie package w/additional support for policy, event, model interface and service registration.  Registrations include additional validation when possible.

Note - when changing to `TipoffPackageProvider` base class, hook configuration method changes from `configurePackage(..)` to `configureTipoffPackage(..)`. 