### PR TITLE
Add helpers that check interface/service registration before use

### DIFF
--- a/src/Contracts/Models/BaseModelInterface.php
+++ b/src/Contracts/Models/BaseModelInterface.php
@@ -11,7 +11,7 @@ interface BaseModelInterface
      * to include docblock with class specific type
      *
      * @param mixed $id
-     * @return self
+     * @return self|null
      */
     public static function find($id);
 

--- a/src/Helpers/Test.php
+++ b/src/Helpers/Test.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Model;
+use Tipoff\Support\Contracts\Models\BaseModelInterface;
+use Tipoff\Support\Contracts\Services\BaseService;
 
 if (! function_exists('randomOrCreate')) {
     /**
@@ -29,6 +31,70 @@ if (! function_exists('randomOrCreate')) {
     }
 }
 
+if (! function_exists('findModel')) {
+    /**
+     * Helper to retrieve model interface by Id but only if
+     * interface class has been registered.  Null if interface
+     * is not registered or model is not found
+     *
+     * @param string $interfaceClass
+     * @param mixed $id
+     * @return BaseModelInterface|null
+     */
+    function findModel(string $interfaceClass, $id)
+    {
+        if (app()->has($interfaceClass)) {
+            /** @var BaseModelInterface $interface */
+            $interface = app($interfaceClass);
+
+            return $interface::find($id);
+        }
+
+        return null;
+    }
+}
+
+if (! function_exists('findModelOrFail')) {
+    /**
+     * Helper to retrieve model interface by Id but only if
+     * interface class has been registered, exception if
+     * not found, null if interface is not registered
+     *
+     * @param string $interfaceClass
+     * @param mixed $id
+     * @return BaseModelInterface|null
+     */
+    function findModelOrFail(string $interfaceClass, $id)
+    {
+        if (app()->has($interfaceClass)) {
+            /** @var BaseModelInterface $interface */
+            $interface = app($interfaceClass);
+
+            return $interface::findOrFail($id);
+        }
+
+        return null;
+    }
+}
+
+if (! function_exists('findService')) {
+    /**
+     * Helper to retrieve service interface if it is
+     * registered, null otherwise
+     *
+     * @param string $interfaceClass
+     * @return BaseService|null
+     */
+    function findService(string $serviceClass)
+    {
+        if (app()->has($serviceClass)) {
+            return app($serviceClass);
+        }
+
+        return null;
+    }
+}
+
 if (! function_exists('createModelStub')) {
     /**
      * Dynamically defines a model class on the fly if not already defined.  Useful
@@ -48,15 +114,11 @@ if (! function_exists('createModelStub')) {
         $classDef = <<<EOT
 namespace {$classNamespace};
 
-use Illuminate\Database\Eloquent\Model;
+use Tipoff\Support\Models\BaseModel;
 use Tipoff\Support\Models\TestModelStub;
 
-class {$classBasename} extends Model {
+class {$classBasename} extends BaseModel {
     use TestModelStub;
-
-    protected \$guarded = [
-        'id',
-    ];
 };
 EOT;
         // alias the anonymous class with your class name

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -50,12 +50,18 @@ class BaseModel extends Model implements BaseModelInterface
 
     public static function find($id)
     {
-        return static::query()->find($id);
+        /** @var BaseModelInterface|null $result */
+        $result = static::query()->find($id);
+
+        return $result;
     }
 
     public static function findOrFail($id)
     {
-        return static::query()->findOrFail($id);
+        /** @var BaseModelInterface $result */
+        $result = static::query()->findOrFail($id);
+
+        return $result;
     }
 
     public function getId()

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -50,12 +50,12 @@ class BaseModel extends Model implements BaseModelInterface
 
     public static function find($id)
     {
-        return static::find($id);
+        return static::query()->find($id);
     }
 
     public static function findOrFail($id)
     {
-        return static::findOrFail($id);
+        return static::query()->findOrFail($id);
     }
 
     public function getId()

--- a/tests/Unit/Helpers/TestTest.php
+++ b/tests/Unit/Helpers/TestTest.php
@@ -100,6 +100,4 @@ class TestTest extends TestCase
 
 class TestService implements BaseService
 {
-
 }
-

--- a/tests/Unit/Helpers/TestTest.php
+++ b/tests/Unit/Helpers/TestTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Tipoff\Support\Tests\Unit\Helpers;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tipoff\Support\Contracts\Models\BaseModelInterface;
+use Tipoff\Support\Contracts\Services\BaseService;
 use Tipoff\Support\Tests\TestCase;
 
 class TestTest extends TestCase
@@ -30,4 +33,73 @@ class TestTest extends TestCase
         $user = randomOrCreate($classInstance);
         $this->assertNotNull($user);
     }
+
+    /** @test */
+    public function test_find_model()
+    {
+        createModelStub(config('tipoff.model_class.user'));
+        config('tipoff.model_class.user')::createTable();
+
+        $className = config('tipoff.model_class.user');
+        $user = randomOrCreate($className);
+
+        // No binding
+        $result = findModel(BaseModelInterface::class, $user->id);
+        $this->assertNull($result);
+
+        // With binding
+        $this->app->bind(BaseModelInterface::class, $className);
+        $result = findModel(BaseModelInterface::class, $user->id);
+        $this->assertNotNull($result);
+        $this->assertEquals($result->getId(), $user->id);
+        $this->assertInstanceOf($className, $result);
+    }
+
+    /** @test */
+    public function test_find_model_or_fail()
+    {
+        createModelStub(config('tipoff.model_class.user'));
+        config('tipoff.model_class.user')::createTable();
+
+        $className = config('tipoff.model_class.user');
+        $user = randomOrCreate($className);
+
+        // No binding
+        $result = findModelOrFail(BaseModelInterface::class, $user->id);
+        $this->assertNull($result);
+
+        $result = findModelOrFail(BaseModelInterface::class, 12324);
+        $this->assertNull($result);
+
+        // With binding
+        $this->app->bind(BaseModelInterface::class, $className);
+        $result = findModelOrFail(BaseModelInterface::class, $user->id);
+        $this->assertNotNull($result);
+        $this->assertEquals($result->getId(), $user->id);
+        $this->assertInstanceOf($className, $result);
+
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model');
+        findModelOrFail(BaseModelInterface::class, 12313);
+    }
+
+    /** @test */
+    public function test_find_service()
+    {
+        // No binding
+        $result = findService(BaseService::class);
+        $this->assertNull($result);
+
+        // With binding
+        $this->app->singleton(BaseService::class, TestService::class);
+        $result = findService(BaseService::class);
+        $this->assertNotNull($result);
+        $this->assertInstanceOf(BaseService::class, $result);
+    }
 }
+
+class TestService implements BaseService
+{
+
+}
+


### PR DESCRIPTION
Simplifies a pattern that I think will be common - checking if interface/service is registered before using it, but not throwing an error if it not registered.  There will also be cases where an exception is appropriate - these would only be for the cases where the dependency can be truly optional.

Also fixes an infinite recursion bug on the find/findOrFail implementations in the BaseModel class.

No rush on this, don't think anyone would be blocked by either of these. 