### PR TITLE
Fix HasCreator Eloquent event call

### DIFF
--- a/src/Traits/HasCreator.php
+++ b/src/Traits/HasCreator.php
@@ -8,7 +8,7 @@ trait HasCreator
 {
     protected static function bootHasCreator()
     {
-        static::saving(function ($model) {
+        static::creating(function ($model) {
             if (auth()->check()) {
                 $model->creator_id = auth()->id();
             }


### PR DESCRIPTION
The hasCreator trait needs to call `static::creating` instead of `static::saving` when setting the `creator_id` because `saving` is called on both creates **and** updates, meaning that the `creator_id` field will be overwritten by the id of any user that updates the model.