### PR TITLE
Fix for not booting package service provider

### DIFF
--- a/src/SupportServiceProvider.php
+++ b/src/SupportServiceProvider.php
@@ -18,6 +18,7 @@ class SupportServiceProvider extends TipoffServiceProvider
      */
     public function boot()
     {
+        parent::boot();
         $this->registerModelsAliases();
         $this->registerNovaModelsAliases();
     }


### PR DESCRIPTION
Booting parent is required for publishing resources (config file) using artisan.