### PR TITLE
Add DiscountableValue object and cast

### DIFF
--- a/src/Casts/DiscountableValue.php
+++ b/src/Casts/DiscountableValue.php
@@ -12,8 +12,6 @@ class DiscountableValue implements CastsAttributes
 
     public function get($model, string $key, $value, array $attributes)
     {
-
-
         return (new \Tipoff\Support\Objects\DiscountableValue((int) ($attributes[$key] ?? ($value ?? 0))))
             ->addDiscounts((int) ($attributes[$this->getDiscountsKey($key)] ?? 0));
     }
@@ -22,7 +20,7 @@ class DiscountableValue implements CastsAttributes
     {
         if (is_null($value)) {
             $value = new \Tipoff\Support\Objects\DiscountableValue(0);
-        } else if (is_int($value)) {
+        } elseif (is_int($value)) {
             $value = new \Tipoff\Support\Objects\DiscountableValue($value);
         }
 

--- a/src/Casts/DiscountableValue.php
+++ b/src/Casts/DiscountableValue.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Support\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class DiscountableValue implements CastsAttributes
+{
+    private const DISCOUNTS_KEY_PATTERN = '%s_discounts';
+
+    public function get($model, string $key, $value, array $attributes)
+    {
+
+
+        return (new \Tipoff\Support\Objects\DiscountableValue((int) ($attributes[$key] ?? ($value ?? 0))))
+            ->addDiscounts((int) ($attributes[$this->getDiscountsKey($key)] ?? 0));
+    }
+
+    public function set($model, string $key, $value, array $attributes)
+    {
+        if (is_null($value)) {
+            $value = new \Tipoff\Support\Objects\DiscountableValue(0);
+        } else if (is_int($value)) {
+            $value = new \Tipoff\Support\Objects\DiscountableValue($value);
+        }
+
+        if ($value instanceof \Tipoff\Support\Objects\DiscountableValue) {
+            return [
+                $key => $value->getOriginalAmount(),
+                $this->getDiscountsKey($key) => $value->getDiscounts(),
+            ];
+        }
+
+        throw new \InvalidArgumentException('DiscountableValue class expected');
+    }
+
+    private function getDiscountsKey(string $key): string
+    {
+        return sprintf(self::DISCOUNTS_KEY_PATTERN, $key);
+    }
+}

--- a/src/Objects/DiscountableValue.php
+++ b/src/Objects/DiscountableValue.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Support\Objects;
+
+class DiscountableValue
+{
+    // Plain Old Object - not model
+    private int $originalAmount;
+    private int $discounts;
+
+    public function __construct(int $originalAmount)
+    {
+        $this->originalAmount = $originalAmount;
+        $this->discounts = 0;
+    }
+
+    public function getOriginalAmount(): int
+    {
+        return $this->originalAmount;
+    }
+
+    public function getDiscounts(): int
+    {
+        return $this->discounts;
+    }
+
+    public function getDiscountedAmount(): int
+    {
+        return max(0, $this->getOriginalAmount() - $this->getDiscounts());
+    }
+
+    public function addDiscounts(int $discounts): DiscountableValue
+    {
+        $result = clone $this;
+        $result->discounts += min($this->getDiscountedAmount(), $discounts);
+
+        return $result;
+    }
+
+    public function reset(): DiscountableValue
+    {
+        return new static($this->originalAmount);
+    }
+
+    public function add(DiscountableValue $other): DiscountableValue
+    {
+        $result = clone $this;
+        $result->originalAmount += $other->getOriginalAmount();
+
+        return $result->addDiscounts($other->getDiscounts());
+    }
+}

--- a/tests/Unit/Casts/DiscountableValueTest.php
+++ b/tests/Unit/Casts/DiscountableValueTest.php
@@ -76,7 +76,7 @@ class DiscountableValueTest extends TestCase
 
         $this->assertEquals([
             'attribute' => 100,
-            'attribute_discounts' => 0
+            'attribute_discounts' => 0,
         ], $value);
     }
 
@@ -89,7 +89,7 @@ class DiscountableValueTest extends TestCase
 
         $this->assertEquals([
             'attribute' => 0,
-            'attribute_discounts' => 0
+            'attribute_discounts' => 0,
         ], $value);
     }
 
@@ -105,7 +105,7 @@ class DiscountableValueTest extends TestCase
 
         $this->assertEquals([
             'attribute' => 1000,
-            'attribute_discounts' => 200
+            'attribute_discounts' => 200,
         ], $value);
     }
 

--- a/tests/Unit/Casts/DiscountableValueTest.php
+++ b/tests/Unit/Casts/DiscountableValueTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Support\Tests\Unit\Casts;
+
+use Illuminate\Database\Eloquent\Model;
+use Tipoff\Support\Objects\DiscountableValue;
+use Tipoff\Support\Tests\TestCase;
+
+class DiscountableValueTest extends TestCase
+{
+    /** @test */
+    public function convert_with_value_only()
+    {
+        $cast = new \Tipoff\Support\Casts\DiscountableValue();
+        $value = $cast->get(new class extends Model {
+        }, 'attribute', 1000, []);
+
+        $this->assertInstanceOf(DiscountableValue::class, $value);
+        $this->assertEquals(1000, $value->getOriginalAmount());
+        $this->assertEquals(0, $value->getDiscounts());
+        $this->assertEquals(1000, $value->getDiscountedAmount());
+    }
+
+    /** @test */
+    public function convert_with_excess_discount()
+    {
+        $cast = new \Tipoff\Support\Casts\DiscountableValue();
+        $value = $cast->get(new class extends Model {
+        }, 'attribute', null, [
+            'attribute' => 200,
+            'attribute_discounts' => 1000,
+        ]);
+
+        $this->assertInstanceOf(DiscountableValue::class, $value);
+        $this->assertEquals(200, $value->getOriginalAmount());
+        $this->assertEquals(200, $value->getDiscounts());
+        $this->assertEquals(0, $value->getDiscountedAmount());
+    }
+
+    /** @test */
+    public function convert_with_value_and_discount()
+    {
+        $cast = new \Tipoff\Support\Casts\DiscountableValue();
+        $value = $cast->get(new class extends Model {
+        }, 'attribute', null, [
+            'attribute' => 1000,
+            'attribute_discounts' => 200,
+        ]);
+
+        $this->assertEquals(1000, $value->getOriginalAmount());
+        $this->assertEquals(200, $value->getDiscounts());
+        $this->assertEquals(800, $value->getDiscountedAmount());
+    }
+
+    /** @test */
+    public function convert_with_nulls()
+    {
+        $cast = new \Tipoff\Support\Casts\DiscountableValue();
+        $value = $cast->get(new class extends Model {
+        }, 'attribute', null, [
+        ]);
+
+        $this->assertEquals(0, $value->getOriginalAmount());
+        $this->assertEquals(0, $value->getDiscounts());
+        $this->assertEquals(0, $value->getDiscountedAmount());
+    }
+
+    /** @test */
+    public function set_by_int()
+    {
+        $cast = new \Tipoff\Support\Casts\DiscountableValue();
+        $value = $cast->set(new class extends Model {
+        }, 'attribute', 100, []);
+
+        $this->assertEquals([
+            'attribute' => 100,
+            'attribute_discounts' => 0
+        ], $value);
+    }
+
+    /** @test */
+    public function set_by_null()
+    {
+        $cast = new \Tipoff\Support\Casts\DiscountableValue();
+        $value = $cast->set(new class extends Model {
+        }, 'attribute', null, []);
+
+        $this->assertEquals([
+            'attribute' => 0,
+            'attribute_discounts' => 0
+        ], $value);
+    }
+
+    /** @test */
+    public function set_by_object()
+    {
+        $value = (new DiscountableValue(1000))
+            ->addDiscounts(200);
+
+        $cast = new \Tipoff\Support\Casts\DiscountableValue();
+        $value = $cast->set(new class extends Model {
+        }, 'attribute', $value, []);
+
+        $this->assertEquals([
+            'attribute' => 1000,
+            'attribute_discounts' => 200
+        ], $value);
+    }
+
+    /** @test */
+    public function set_by_non_money_fails()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('DiscountableValue class expected');
+
+        $cast = new \Tipoff\Support\Casts\DiscountableValue();
+        $cast->set(new class extends Model {
+        }, 'attribute', 'NotValid', []);
+    }
+}

--- a/tests/Unit/Objects/DiscountableValueTest.php
+++ b/tests/Unit/Objects/DiscountableValueTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Support\Tests\Unit\Objects;
+
+use Tipoff\Support\Objects\DiscountableValue;
+use Tipoff\Support\Tests\TestCase;
+
+class DiscountableValueTest extends TestCase
+{
+    /** @test */
+    public function construct_with_value()
+    {
+        $value = new DiscountableValue(1000);
+
+        $this->assertEquals(1000, $value->getOriginalAmount());
+        $this->assertEquals(0, $value->getDiscounts());
+        $this->assertEquals(1000, $value->getDiscountedAmount());
+    }
+
+    /** @test */
+    public function add_discounts()
+    {
+        $value = (new DiscountableValue(1000))
+            ->addDiscounts(200);
+
+        $this->assertEquals(1000, $value->getOriginalAmount());
+        $this->assertEquals(200, $value->getDiscounts());
+        $this->assertEquals(800, $value->getDiscountedAmount());
+    }
+
+    /** @test */
+    public function add_multiple_discounts()
+    {
+        $value = (new DiscountableValue(1000))
+            ->addDiscounts(300)
+            ->addDiscounts(300)
+            ->addDiscounts(300);
+
+        $this->assertEquals(1000, $value->getOriginalAmount());
+        $this->assertEquals(900, $value->getDiscounts());
+        $this->assertEquals(100, $value->getDiscountedAmount());
+
+        $result = $value->addDiscounts(300);
+        $this->assertEquals(1000, $result->getOriginalAmount());
+        $this->assertEquals(1000, $result->getDiscounts());
+        $this->assertEquals(0, $result->getDiscountedAmount());
+
+        // Value should be unchanged
+        $this->assertEquals(1000, $value->getOriginalAmount());
+        $this->assertEquals(900, $value->getDiscounts());
+        $this->assertEquals(100, $value->getDiscountedAmount());
+    }
+
+    /** @test */
+    public function add_discountable_value()
+    {
+        $value1 = (new DiscountableValue(1000))
+            ->addDiscounts(300);
+
+        $value2 = (new DiscountableValue(500))
+            ->addDiscounts(100);
+
+        $result = $value1->add($value2);
+        $this->assertEquals(1500, $result->getOriginalAmount());
+        $this->assertEquals(400, $result->getDiscounts());
+        $this->assertEquals(1100, $result->getDiscountedAmount());
+
+        // Value 1 unchanged
+        $this->assertEquals(1000, $value1->getOriginalAmount());
+        $this->assertEquals(300, $value1->getDiscounts());
+        $this->assertEquals(700, $value1->getDiscountedAmount());
+
+        // Value 2 unchanged
+        $this->assertEquals(500, $value2->getOriginalAmount());
+        $this->assertEquals(100, $value2->getDiscounts());
+        $this->assertEquals(400, $value2->getDiscountedAmount());
+    }
+}

--- a/tests/Unit/Objects/DiscountableValueTest.php
+++ b/tests/Unit/Objects/DiscountableValueTest.php
@@ -31,6 +31,23 @@ class DiscountableValueTest extends TestCase
     }
 
     /** @test */
+    public function reset()
+    {
+        $value = (new DiscountableValue(1000))
+            ->addDiscounts(200);
+
+        $result = $value->reset();
+        $this->assertEquals(1000, $result->getOriginalAmount());
+        $this->assertEquals(0, $result->getDiscounts());
+        $this->assertEquals(1000, $result->getDiscountedAmount());
+
+        // Value should be unchanged
+        $this->assertEquals(1000, $value->getOriginalAmount());
+        $this->assertEquals(200, $value->getDiscounts());
+        $this->assertEquals(800, $value->getDiscountedAmount());
+    }
+
+    /** @test */
     public function add_multiple_discounts()
     {
         $value = (new DiscountableValue(1000))


### PR DESCRIPTION
This is a plain-old-object (and its supporting Cast) that I'm looking to use within the Cart (for shipping) and CartItem (for amount) interfaces.  Since those interfaces will end up in this package, this object is needed here to allow for that.  I've added it to the `Tipoff\Support\Objects` namespace - happy to move to a different folder if desired.

Purpose of this object is to allow safe handling of a value field and its discounts (ensures discount never exceeds original value, has support for accumulation by an `add` method).

