### PR TITLE
Add standard methods to test ownership and scope by user

### DIFF
--- a/src/Contracts/Models/BaseModelInterface.php
+++ b/src/Contracts/Models/BaseModelInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tipoff\Support\Contracts\Models;
 
+use Illuminate\Database\Eloquent\Builder;
+
 interface BaseModelInterface
 {
     /**
@@ -25,4 +27,21 @@ interface BaseModelInterface
      * @return mixed|null
      */
     public function getId();
+
+    /**
+     * Determine if User owns this resource
+     *
+     * @param UserInterface $user
+     * @return bool
+     */
+    public function isOwner(UserInterface $user): bool;
+
+    /**
+     * Scope results to only those that given user should have access to.
+     *
+     * @param Builder $query
+     * @param UserInterface $user
+     * @return Builder
+     */
+    public function scopeVisibleBy(Builder $query, UserInterface $user): Builder;
 }

--- a/src/Contracts/Models/UserInterface.php
+++ b/src/Contracts/Models/UserInterface.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Tipoff\Support\Contracts\Models;
 
-interface UserInterface
+use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
+
+interface UserInterface extends AuthenticatableContract, AuthorizableContract, BaseModelInterface
 {
     public function hasRole($roles, string $guard = null): bool;
 

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -96,6 +96,16 @@ class BaseModel extends Model implements BaseModelInterface
 
     public function scopeVisibleBy(Builder $query, UserInterface $user): Builder
     {
+        return $this->scopeNeverVisible($query);
+    }
+
+    protected function scopeNeverVisible(Builder $query): Builder
+    {
         return $query->whereRaw('1 = 0');
+    }
+
+    protected function scopeAlwaysVisible(Builder $query): Builder
+    {
+        return $query;
     }
 }

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Tipoff\Support\Models;
 
 use Assert\Assert;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Tipoff\Support\Contracts\Models\BaseModelInterface;
+use Tipoff\Support\Contracts\Models\UserInterface;
 
 class BaseModel extends Model implements BaseModelInterface
 {
@@ -85,5 +87,15 @@ class BaseModel extends Model implements BaseModelInterface
     public function getId()
     {
         return $this->id;
+    }
+
+    public function isOwner(UserInterface $user): bool
+    {
+        return false;
+    }
+
+    public function scopeVisibleBy(Builder $query, UserInterface $user): Builder
+    {
+        return $query->whereRaw('1 = 0');
     }
 }

--- a/tests/Unit/Models/BaseModelTest.php
+++ b/tests/Unit/Models/BaseModelTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Support\Tests\Unit\Models;
+
+use Illuminate\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Auth\Access\Authorizable;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tipoff\Support\Contracts\Models\UserInterface;
+use Tipoff\Support\Models\BaseModel;
+use Tipoff\Support\Models\TestModelStub;
+use Tipoff\Support\Tests\TestCase;
+
+class BaseModelTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test  */
+    public function get_id()
+    {
+        TestModel::createTable();;
+
+        /** @var TestModel $model */
+        $model = TestModel::create([]);
+        $this->assertNotNull($model);
+
+        $this->assertEquals($model->id, $model->getId());
+    }
+
+    /** @test  */
+    public function find()
+    {
+        TestModel::createTable();;
+
+        $result = TestModel::find(1);
+        $this->assertNull($result);
+
+        /** @var TestModel $model */
+        $model = TestModel::create([]);
+
+        $result = TestModel::find($model->id);
+        $this->assertNotNull($result);
+
+        $this->assertEquals($model->getId(), $result->getId());
+    }
+
+    /** @test  */
+    public function find_or_fail()
+    {
+        TestModel::createTable();;
+
+        /** @var TestModel $model */
+        $model = TestModel::create([]);
+
+        $result = TestModel::findOrFail($model->id);
+        $this->assertNotNull($result);
+
+        $this->assertEquals($model->getId(), $result->getId());
+
+        $this->expectException(ModelNotFoundException::class);
+
+        TestModel::findOrFail(1234);
+    }
+
+    /** @test  */
+    public function default_is_owner_is_false()
+    {
+        TestModel::createTable();;
+
+        /** @var TestModel $model */
+        $model = TestModel::create([]);
+        $this->assertNotNull($model);
+
+        $this->assertFalse($model->isOwner($model));
+    }
+
+    /** @test  */
+    public function default_visible_by_is_hidden()
+    {
+        TestModel::createTable();;
+
+        foreach(range(1,10) as $i) {
+            TestModel::create([]);
+        }
+
+        $this->assertDatabaseCount('test_models', 10);
+
+        $user = TestModel::create([]);
+        $models = TestModel::query()->visibleBy($user)->get();
+
+        $this->assertCount(0, $models);
+    }
+}
+
+class TestModel extends BaseModel implements UserInterface {
+    use TestModelStub;
+    use Authenticatable;
+    use Authorizable;
+
+    public function hasRole($roles, string $guard = null): bool
+    {
+        return false;
+    }
+
+    public function hasPermissionTo($permission, $guardName = null): bool
+    {
+        return false;
+    }
+}

--- a/tests/Unit/Models/BaseModelTest.php
+++ b/tests/Unit/Models/BaseModelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tipoff\Support\Tests\Unit\Models;
 
 use Illuminate\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -92,12 +93,56 @@ class BaseModelTest extends TestCase
 
         $this->assertCount(0, $models);
     }
+
+    /** @test  */
+    public function always_visible()
+    {
+        TestModel::createTable();;
+
+        foreach(range(1,10) as $i) {
+            TestModel::create([]);
+        }
+
+        $this->assertDatabaseCount('test_models', 10);
+
+        $user = TestModel::create([]);
+        $models = TestModel::query()->alwaysVisible($user)->get();
+
+        $this->assertCount(11, $models);
+    }
+
+    /** @test  */
+    public function never_visible()
+    {
+        TestModel::createTable();;
+
+        foreach(range(1,10) as $i) {
+            TestModel::create([]);
+        }
+
+        $this->assertDatabaseCount('test_models', 10);
+
+        $user = TestModel::create([]);
+        $models = TestModel::query()->neverVisible($user)->get();
+
+        $this->assertCount(0, $models);
+    }
 }
 
 class TestModel extends BaseModel implements UserInterface {
     use TestModelStub;
     use Authenticatable;
     use Authorizable;
+
+    public function scopeNeverVisible(Builder $query): Builder
+    {
+        return parent::scopeNeverVisible($query);
+    }
+
+    public function scopeAlwaysVisible(Builder $query): Builder
+    {
+        return parent::scopeAlwaysVisible($query);
+    }
 
     public function hasRole($roles, string $guard = null): bool
     {

--- a/tests/Unit/Models/BaseModelTest.php
+++ b/tests/Unit/Models/BaseModelTest.php
@@ -20,7 +20,8 @@ class BaseModelTest extends TestCase
     /** @test  */
     public function get_id()
     {
-        TestModel::createTable();;
+        TestModel::createTable();
+        ;
 
         /** @var TestModel $model */
         $model = TestModel::create([]);
@@ -32,7 +33,8 @@ class BaseModelTest extends TestCase
     /** @test  */
     public function find()
     {
-        TestModel::createTable();;
+        TestModel::createTable();
+        ;
 
         $result = TestModel::find(1);
         $this->assertNull($result);
@@ -49,7 +51,8 @@ class BaseModelTest extends TestCase
     /** @test  */
     public function find_or_fail()
     {
-        TestModel::createTable();;
+        TestModel::createTable();
+        ;
 
         /** @var TestModel $model */
         $model = TestModel::create([]);
@@ -67,7 +70,8 @@ class BaseModelTest extends TestCase
     /** @test  */
     public function default_is_owner_is_false()
     {
-        TestModel::createTable();;
+        TestModel::createTable();
+        ;
 
         /** @var TestModel $model */
         $model = TestModel::create([]);
@@ -79,9 +83,10 @@ class BaseModelTest extends TestCase
     /** @test  */
     public function default_visible_by_is_hidden()
     {
-        TestModel::createTable();;
+        TestModel::createTable();
+        ;
 
-        foreach(range(1,10) as $i) {
+        foreach (range(1, 10) as $i) {
             TestModel::create([]);
         }
 
@@ -94,7 +99,8 @@ class BaseModelTest extends TestCase
     }
 }
 
-class TestModel extends BaseModel implements UserInterface {
+class TestModel extends BaseModel implements UserInterface
+{
     use TestModelStub;
     use Authenticatable;
     use Authorizable;

--- a/tests/Unit/Models/BaseModelTest.php
+++ b/tests/Unit/Models/BaseModelTest.php
@@ -102,9 +102,10 @@ class BaseModelTest extends TestCase
     /** @test  */
     public function always_visible()
     {
-        TestModel::createTable();;
+        TestModel::createTable();
+        ;
 
-        foreach(range(1,10) as $i) {
+        foreach (range(1, 10) as $i) {
             TestModel::create([]);
         }
 
@@ -119,9 +120,10 @@ class BaseModelTest extends TestCase
     /** @test  */
     public function never_visible()
     {
-        TestModel::createTable();;
+        TestModel::createTable();
+        ;
 
-        foreach(range(1,10) as $i) {
+        foreach (range(1, 10) as $i) {
             TestModel::create([]);
         }
 


### PR DESCRIPTION
Adds `isOwner(UserInterface $user)` and `scopeVisibleBy(Builder $query, UserInterface $user)` as `BaseModelInterface` methods with a default implementation that returns no access / no results.

This brings across and formalizes a common approach to API controller implementation that was being used in tger/tger.

This also modifies the `UserInterface` contract so it extends all of AuthenticatableContract, AuthorizableContract, BaseModelInterface.