### PR TITLE
Add support for models to optionally supply default transformer instance and default view component

### DIFF
--- a/src/Contracts/Checkout/BaseItemContainerInterface.php
+++ b/src/Contracts/Checkout/BaseItemContainerInterface.php
@@ -6,10 +6,16 @@ namespace Tipoff\Support\Contracts\Checkout;
 
 use Illuminate\Support\Collection;
 use Tipoff\Support\Contracts\Models\BaseModelInterface;
+use Tipoff\Support\Contracts\Models\UserInterface;
 use Tipoff\Support\Objects\DiscountableValue;
 
 interface BaseItemContainerInterface extends BaseModelInterface
 {
+    /**
+     * Returns the user that owns the container
+     */
+    public function getUser(): UserInterface;
+
     /**
      * Returns the DiscountableValue representing the total item amount / total item amount discounts
      */

--- a/src/Contracts/Checkout/CodedCartAdjustment.php
+++ b/src/Contracts/Checkout/CodedCartAdjustment.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Tipoff\Support\Contracts\Checkout;
 
-interface CodedCartAdjustment
+use Tipoff\Support\Contracts\Models\BaseModelInterface;
+
+interface CodedCartAdjustment extends BaseModelInterface
 {
     /**
      * Locates an active adjustment by its code.  Null if nothing found.
@@ -18,7 +20,7 @@ interface CodedCartAdjustment
 
     /**
      * @param CartInterface $cart
-     * @return array|string[]
+     * @return array|CodedCartAdjustment[]
      */
     public static function getCodesForCart(CartInterface $cart): array;
 

--- a/src/Contracts/Checkout/CodedCartAdjustment.php
+++ b/src/Contracts/Checkout/CodedCartAdjustment.php
@@ -25,6 +25,16 @@ interface CodedCartAdjustment extends BaseModelInterface
     public static function getCodesForCart(CartInterface $cart): array;
 
     /**
+     * @return string|null
+     */
+    public function getCode();
+
+    /**
+     * @return int|null
+     */
+    public function getAmount();
+
+    /**
      * Associates adjustment with cart
      *
      * @param CartInterface $cart

--- a/src/Contracts/Models/BaseModelInterface.php
+++ b/src/Contracts/Models/BaseModelInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tipoff\Support\Contracts\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use Tipoff\Support\Transformers\BaseTransformer;
 
 interface BaseModelInterface
 {
@@ -22,6 +23,23 @@ interface BaseModelInterface
      * @return self
      */
     public static function findOrFail($id);
+
+    /**
+     * Return transformer instance for model, or null if transformation not supported.
+     *
+     * @param mixed|null $context
+     * @return BaseTransformer|null
+     */
+    public function getTransformer($context = null);
+
+    /**
+     * Get default view component for model, or null if not supported.  Can be helpful
+     * for dynamic component rendering.
+     *
+     * @param mixed|null $context
+     * @return string|null
+     */
+    public function getViewComponent($context = null);
 
     /**
      * @return mixed|null

--- a/src/Contracts/Sellable/Sellable.php
+++ b/src/Contracts/Sellable/Sellable.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Tipoff\Support\Contracts\Sellable;
 
-interface Sellable
+use Tipoff\Support\Contracts\Models\BaseModelInterface;
+
+interface Sellable extends BaseModelInterface
 {
     public function getDescription(): string;
 

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -9,7 +9,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Tipoff\Support\Contracts\Models\BaseModelInterface;
 use Tipoff\Support\Contracts\Models\UserInterface;
-use Tipoff\Support\Transformers\BaseTransformer;
 
 class BaseModel extends Model implements BaseModelInterface
 {

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Tipoff\Support\Contracts\Models\BaseModelInterface;
 use Tipoff\Support\Contracts\Models\UserInterface;
+use Tipoff\Support\Transformers\BaseTransformer;
 
 class BaseModel extends Model implements BaseModelInterface
 {
@@ -82,6 +83,16 @@ class BaseModel extends Model implements BaseModelInterface
         $result = static::query()->findOrFail($id);
 
         return $result;
+    }
+
+    public function getTransformer($context = null)
+    {
+        return null;
+    }
+
+    public function getViewComponent($context = null)
+    {
+        return null;
     }
 
     public function getId()


### PR DESCRIPTION
Extends `BaseModelInterface` with `getTransformer(...)` and `getViewComponent(...)` methods allowing a model to provide defaults for both.   Includes default implementation in `BaseModel` that returns null for both.

Modifies `Sellable` and `CodedCartAdjustment` to both extend `BaseModelInterface` providing access to these new methods.