### PR TITLE
Add SEO class aliases #21

### DIFF
--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -30,8 +30,6 @@ return [
 
         'company' => \Tipoff\Seo\Models\Company::class,
 
-        'company_user' => \Tipoff\Seo\Models\CompanyUser::class,
-
         'contact' => \Tipoff\Forms\Models\Contact::class,
 
         'customer' => \Tipoff\Addresses\Models\Customer::class, // Will be renamed later to address when new features added

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -30,11 +30,15 @@ return [
 
         'company' => \Tipoff\Seo\Models\Company::class,
 
+        'company_user' => \Tipoff\Seo\Models\CompanyUser::class,
+
         'contact' => \Tipoff\Forms\Models\Contact::class,
 
         'customer' => \Tipoff\Addresses\Models\Customer::class, // Will be renamed later to address when new features added
 
         'discount' => \Tipoff\Discounts\Models\Discount::class,
+
+        'domain' => \Tipoff\Seo\Models\Domain::class,
 
         'fee' => \Tipoff\Fees\Models\Fee::class,
 
@@ -60,6 +64,8 @@ return [
 
         'key' => \Tipoff\GoogleApi\Models\Key::class,
 
+        'keyword' => \Tipoff\Seo\Models\Keyword::class,
+
         'location' => \Tipoff\Locations\Models\Location::class,
 
         'market' => \Tipoff\Locations\Models\Market::class,
@@ -76,11 +82,15 @@ return [
 
         'payment' => \Tipoff\Payments\Models\Payment::class,
 
+        'place' => \Tipoff\Seo\Models\Place::class,
+
         'post' => \DrewRoberts\Blog\Models\Post::class,
 
         'profile_link' => \Tipoff\Locations\Models\ProfileLink::class,
 
         'rate' => \Tipoff\EscapeRoom\Models\Rate::class,
+
+        'ranking' => \Tipoff\Seo\Models\Ranking::class,
 
         'recurring_schedule' => \Tipoff\Scheduler\Models\RecurringSchedule::class,
 
@@ -91,6 +101,8 @@ return [
         'room' => \Tipoff\EscapeRoom\Models\Room::class,
 
         'schedule_eraser' => \Tipoff\Scheduler\Models\ScheduleEraser::class,
+
+        'search_volume' => \Tipoff\Seo\Models\SearchVolume::class,
 
         'series' => \DrewRoberts\Blog\Models\Series::class,
 
@@ -121,6 +133,8 @@ return [
         'voucher' => \Tipoff\Vouchers\Models\Voucher::class,
 
         'voucher_type' => \Tipoff\Vouchers\Models\VoucherType::class,
+
+        'webpage' => \Tipoff\Seo\Models\Webpage::class,
 
     ],
 


### PR DESCRIPTION
I realized when going back to https://github.com/tipoff/locations/pull/55 , that none of the SEO classes were here. Added them in this PR.