### PR TITLE
Omnia/feature/21 add all package models and nova resources to config

### DIFF
--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -222,6 +222,8 @@ return [
 
         'location' => \Tipoff\Locations\Nova\Location::class,
 
+        'location_tax' => \Tipoff\Taxes\Nova\LocationTax::class,
+
         'market' => \Tipoff\Locations\Nova\Market::class,
 
         'note' => \Tipoff\Notes\Nova\Note::class,

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -102,6 +102,8 @@ return [
 
         'post' => \DrewRoberts\Blog\Models\Post::class,
 
+        'product' => \Tipoff\Products\Models\Product::class,
+
         'profile_link' => \Tipoff\Seo\Models\ProfileLink::class,
 
         'rate' => \Tipoff\EscapeRoom\Models\Rate::class,

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -20,6 +20,8 @@ return [
 
         'address' => \Tipoff\Addresses\Models\Address::class,
 
+        'alternate_email' => \Tipoff\Authorization\Models\AlternateEmail::class,
+
         'block' => \Tipoff\Scheduler\Models\Block::class,
 
         'booking' => \Tipoff\Bookings\Models\Booking::class,

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -164,6 +164,8 @@ return [
 
         'voucher_type' => \Tipoff\Vouchers\Models\VoucherType::class,
 
+        'waiver' => \Tipoff\Waivers\Models\Waiver::class,
+
         'webpage' => \Tipoff\Seo\Models\Webpage::class,
 
         'zip' => \Tipoff\Addresses\Models\Zip::class,

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -256,6 +256,8 @@ return [
 
         'slot' => \Tipoff\Scheduler\Nova\Slot::class,
 
+        'slot_bookings' => \Tipoff\Bookings\Nova\Slot::class,
+
         'snapshot' => \Tipoff\Reviews\Nova\Snapshot::class,
 
         'state' => \Tipoff\Addresses\Nova\State::class,

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -64,6 +64,8 @@ return [
 
         'key' => \Tipoff\GoogleApi\Models\Key::class,
 
+        'key_agora' => \Tipoff\LaravelAgoraApi\Models\Key::class,
+
         'keyword' => \Tipoff\Seo\Models\Keyword::class,
 
         'location' => \Tipoff\Locations\Models\Location::class,

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -238,6 +238,8 @@ return [
 
         'post' => \DrewRoberts\Blog\Nova\Post::class,
 
+        'product' => \Tipoff\Products\Nova\Product::class,
+
         'profile_link' => \Tipoff\Seo\Nova\ProfileLink::class,
 
         'ranking' => \Tipoff\Seo\Nova\Ranking::class,

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -26,6 +26,8 @@ return [
 
         'booking' => \Tipoff\Bookings\Models\Booking::class,
 
+        'booking_category' => \Tipoff\Bookings\Models\BookingCategory::class,
+
         'cart' => \Tipoff\Checkout\Models\Cart::class,
 
         'cart_item' => \Tipoff\Checkout\Models\CartItem::class,

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -128,8 +128,6 @@ return [
 
         'slot' => \Tipoff\Scheduler\Models\Slot::class,
 
-        'slot_bookings' => \Tipoff\Bookings\Models\Slot::class,
-
         'snapshot' => \Tipoff\Reviews\Models\Snapshot::class,
 
         'state' => \Tipoff\Addresses\Models\State::class,
@@ -263,8 +261,6 @@ return [
         'signature' => \Tipoff\Waivers\Nova\Signature::class,
 
         'slot' => \Tipoff\Scheduler\Nova\Slot::class,
-
-        'slot_bookings' => \Tipoff\Bookings\Nova\Slot::class,
 
         'snapshot' => \Tipoff\Reviews\Nova\Snapshot::class,
 

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -124,6 +124,8 @@ return [
 
         'slot' => \Tipoff\Scheduler\Models\Slot::class,
 
+        'slot_bookings' => \Tipoff\Bookings\Models\Slot::class,
+
         'snapshot' => \Tipoff\Reviews\Models\Snapshot::class,
 
         'state' => \Tipoff\Addresses\Models\State::class,

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -188,6 +188,10 @@ return [
 
         'domain' => \Tipoff\Seo\Nova\Domain::class,
 
+        'escape_room_location' => \Tipoff\EscapeRoom\Nova\EscapeRoomLocation::class,
+
+        'escape_room_market' => \Tipoff\EscapeRoom\Nova\EscapeRoomMarket::class,
+
         'fee' => \Tipoff\Fees\Nova\Fee::class,
 
         'feedback' => \Tipoff\Feedback\Nova\Feedback::class,

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -46,6 +46,10 @@ return [
 
         'domain' => \Tipoff\Seo\Models\Domain::class,
 
+        'escape_room_location' => \Tipoff\EscapeRoom\Models\EscapeRoomLocation::class,
+
+        'escape_room_market' => \Tipoff\EscapeRoom\Models\EscapeRoomMarket::class,
+
         'fee' => \Tipoff\Fees\Models\Fee::class,
 
         'feedback' => \Tipoff\Feedback\Models\Feedback::class,

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -76,6 +76,8 @@ return [
 
         'key_agora' => \Tipoff\LaravelAgoraApi\Models\Key::class,
 
+        'key_serp' => \Tipoff\LaravelSerpapi\Models\Key::class,
+
         'keyword' => \Tipoff\Seo\Models\Keyword::class,
 
         'location' => \Tipoff\Locations\Models\Location::class,

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -64,6 +64,8 @@ return [
 
         'gmb_hour' =>  \Tipoff\Locations\Models\GmbHour::class,
 
+        'hold' => \Tipoff\Scheduler\Models\Hold::class,
+
         'image' => \DrewRoberts\Media\Models\Image::class,
 
         'insight' => \Tipoff\Reviews\Models\Insight::class,

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -304,6 +304,8 @@ return [
 
         'voucher_type' => \Tipoff\Vouchers\Nova\VoucherType::class,
 
+        'waiver' => \Tipoff\Waivers\Nova\Waiver::class,
+
         'webpage' => \Tipoff\Seo\Nova\Webpage::class,
 
         'zip' => \Tipoff\Addresses\Nova\Zip::class,

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -84,6 +84,8 @@ return [
 
         'location_payment_setting' => \Tipoff\Payments\Models\LocationPaymentSetting::class,
 
+        'location_tax' => \Tipoff\Taxes\Models\LocationTax::class,
+
         'market' => \Tipoff\Locations\Models\Market::class,
 
         'note' => \Tipoff\Notes\Models\Note::class,

--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -78,6 +78,8 @@ return [
 
         'location' => \Tipoff\Locations\Models\Location::class,
 
+        'location_payment_setting' => \Tipoff\Payments\Models\LocationPaymentSetting::class,
+
         'market' => \Tipoff\Locations\Models\Market::class,
 
         'note' => \Tipoff\Notes\Models\Note::class,


### PR DESCRIPTION
#21 

- added all package Models / Nova resources to Support/Config

_Note:_  Some Models did not have a paired Nova resource.  
The following Nova resources do not exist yet, and were not added to the _config_.  I can add them in preemptively if you would like.

- Bookings / BookingCategory
- Authorization / AlternateEmail
- Checkout / Cart
- Checkout / CartItem
- Fees / LocationFee
- FlexScheduling / FlexDay
- Locations / GmbDetail
- Locations / GmbHour
- Payments / LocationPaymentSetting
- Scheduler / Hold