### PR TITLE
Add support for hasDataMigrations which are not run during tests

### DIFF
--- a/src/TipoffPackage.php
+++ b/src/TipoffPackage.php
@@ -69,6 +69,14 @@ class TipoffPackage extends Package
 
     public array $bindings = [];
 
+    /**
+     * [
+     *    '/path/to/seeder/migration/files',
+     *    // ..
+     * ]
+     */
+    public array $dataMigrationPaths = [];
+
     public function __construct(Package $package)
     {
         $this->setBasePath($package->basePath);
@@ -182,6 +190,15 @@ class TipoffPackage extends Package
     public function hasBindings(array $bindings): self
     {
         $this->bindings = array_merge($this->bindings, $bindings);
+
+        return $this;
+    }
+
+    public function hasDataMigrations(...$dataMigrationPaths): self
+    {
+        $this->dataMigrationPaths = array_unique(
+            array_merge($this->dataMigrationPaths, $dataMigrationPaths ?: [ $this->basePath.'/../database/datamigrations' ])
+        );
 
         return $this;
     }

--- a/src/TipoffServiceProvider.php
+++ b/src/TipoffServiceProvider.php
@@ -34,6 +34,10 @@ abstract class TipoffServiceProvider extends PackageServiceProvider
 
         $this->loadMigrationsFrom($this->package->basePath.'/../database/migrations');
 
+        if ($package->dataMigrationPaths && !app()->runningUnitTests()) {
+            $this->loadMigrationsFrom($package->dataMigrationPaths);
+        }
+
         $this->loadViewComponentsAs('tipoff', $package->bladeComponents);
     }
 

--- a/src/TipoffServiceProvider.php
+++ b/src/TipoffServiceProvider.php
@@ -34,7 +34,7 @@ abstract class TipoffServiceProvider extends PackageServiceProvider
 
         $this->loadMigrationsFrom($this->package->basePath.'/../database/migrations');
 
-        if ($package->dataMigrationPaths && !app()->runningUnitTests()) {
+        if ($package->dataMigrationPaths && ! app()->runningUnitTests()) {
             $this->loadMigrationsFrom($package->dataMigrationPaths);
         }
 


### PR DESCRIPTION
With no parameters, `database/datamigrations` directory is assumed.