### PR TITLE
Change when api/web enabled flag is checked during package registration

### DIFF
--- a/src/TipoffPackage.php
+++ b/src/TipoffPackage.php
@@ -77,6 +77,10 @@ class TipoffPackage extends Package
      */
     public array $dataMigrationPaths = [];
 
+    public array $apiRouteFileNames = [];
+
+    public array $webRouteFileNames = [];
+
     public function __construct(Package $package)
     {
         $this->setBasePath($package->basePath);
@@ -94,36 +98,28 @@ class TipoffPackage extends Package
 
     public function hasApiRoute(string $routeFileName): self
     {
-        if (config('tipoff.api.enabled')) {
-            return parent::hasRoute($routeFileName);
-        }
+        $this->apiRouteFileNames[] = $routeFileName;
 
         return $this;
     }
 
     public function hasApiRoutes(...$routeFileNames): self
     {
-        if (config('tipoff.api.enabled')) {
-            return parent::hasRoutes(...$routeFileNames);
-        }
+        $this->apiRouteFileNames = array_merge($this->apiRouteFileNames, collect($routeFileNames)->flatten()->toArray());
 
         return $this;
     }
 
     public function hasWebRoute(string $routeFileName): self
     {
-        if (config('tipoff.web.enabled')) {
-            return parent::hasRoute($routeFileName);
-        }
+        $this->webRouteFileNames[] = $routeFileName;
 
         return $this;
     }
 
     public function hasWebRoutes(...$routeFileNames): self
     {
-        if (config('tipoff.web.enabled')) {
-            return parent::hasRoutes(...$routeFileNames);
-        }
+        $this->webRouteFileNames = array_merge($this->webRouteFileNames, collect($routeFileNames)->flatten()->toArray());
 
         return $this;
     }

--- a/src/TipoffServiceProvider.php
+++ b/src/TipoffServiceProvider.php
@@ -39,6 +39,14 @@ abstract class TipoffServiceProvider extends PackageServiceProvider
         }
 
         $this->loadViewComponentsAs('tipoff', $package->bladeComponents);
+
+        if (config('tipoff.web.enabled')) {
+            $package->routeFileNames = array_merge($package->routeFileNames, $package->webRouteFileNames);
+        }
+
+        if (config('tipoff.api.enabled')) {
+            $package->routeFileNames = array_merge($package->routeFileNames, $package->apiRouteFileNames);
+        }
     }
 
     public function packageRegistered()


### PR DESCRIPTION
Need to defer testing of the config flag until packages are actually booting to make sure `config/tipoff.php` has actually been loaded.  (Found trying to use new product routes in demo app.)