### PR TITLE
Add CartInterface::queuedUpsertItem and CartInterface::route

### DIFF
--- a/resources/views/partials/_errors.blade.php
+++ b/resources/views/partials/_errors.blade.php
@@ -1,0 +1,3 @@
+@if($errors->any())
+    {!! implode('', $errors->all('<div>:message</div>')) !!}
+@endif

--- a/src/Contracts/Checkout/CartInterface.php
+++ b/src/Contracts/Checkout/CartInterface.php
@@ -10,12 +10,22 @@ use Tipoff\Support\Objects\DiscountableValue;
 interface CartInterface extends BaseItemContainerInterface
 {
     /**
+     * Resolve a route name to an url, using a package default if the route doesn't exist.
+     *
+     * @param string $name
+     * @param array $parameters
+     * @param bool $absolute
+     * @return string
+     */
+    public static function route(string $name, array $parameters = [], bool $absolute = true): string;
+
+    /**
      * Retrieve or create the current active cart for the given user.
      *
-     * @param int $userId
+     * @param int $emailAddressId
      * @return static
      */
-    public static function activeCart(int $userId): self;
+    public static function activeCart(int $emailAddressId): self;
 
     /**
      * Creates a new, DETACHED, cart item with required information.  Use `upsertItem` to attach
@@ -28,6 +38,17 @@ interface CartInterface extends BaseItemContainerInterface
      * @return CartItemInterface
      */
     public static function createItem(Sellable $sellable, string $itemId, $amount, int $quantity = 1): CartItemInterface;
+
+    /**
+     * Performs an upsertItem on the activeCart when emailAddressId is provided.  When emailAddressId is not provided,
+     * the cartItem is stored in session data.  When/if a login event is raised, the cartItem in session data will
+     * be moved to the logged in users cart.
+     *
+     * @param CartItemInterface $cartItem
+     * @param int|null $emailAddressId
+     * @return CartItemInterface
+     */
+    public static function queuedUpsertItem(CartItemInterface $cartItem, ?int $emailAddressId = null): CartItemInterface;
 
     /**
      * Adds a newly created cart item to the cart or indicates an existing item has been changed. Item is validated as


### PR DESCRIPTION
Cart item queuing is required to support email login after an "add to cart" button is clicked.  It does this by making the add-to-cart POST routes accessible w/o requiring login.  The controller for the post creates the cart item and then calls `queuedUpsertItem(...)` which will either add the item immediately, or defer addition by storing in session data until a user login even occurs.    By redirecting to the cart (which is an auth protected route) after addition, the login page will appear when needed.  And, because the cart is a GET and not a POST, laravel's redirect to `intended` will work properly, showing the cart after email capture.