### PR TITLE
Nova Website Content -> Pages linking incorrectly on blue 'view' button #140

### DIFF
--- a/config/tipoff.php
+++ b/config/tipoff.php
@@ -11,7 +11,7 @@ return [
 
     'web' => [
         'enabled' => true,
-        'uri_prefix' => '',
+        'uri_prefix' => '/',
         'middleware_group' => 'web',
         'auth_middleware' => 'auth',
     ],


### PR DESCRIPTION
Spoke with @wolfrednicolas and this change will break other models.
#140 
The blue 'view' button on click opens new tab to a URL missing a '/'
I verified these changes locally, and it is working.
- set config('tipoff.web.uri_prefix') => '/'
can set to anything you prefer

![image](https://user-images.githubusercontent.com/62731054/116122847-4949b200-a690-11eb-9484-0706dd72400d.png)
![image](https://user-images.githubusercontent.com/62731054/116122892-55ce0a80-a690-11eb-8031-c32985d09afd.png)